### PR TITLE
chore: promote to full release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.0.0-alpha.0] - 2026-05-03
+## [2.0.0] - 2026-05-03
 
 ### Added
 - **`auth` command** — manage named connection profiles
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `template list` now lists the full template catalog instead of only built-in presets
 - Version string is now sourced directly from `package.json` instead of being hardcoded
-- The npm prerelease is published under the `alpha` dist-tag
+- The npm release is published under the `latest` dist-tag
 
 ### Planned
 - GitHub Issues integration
@@ -255,7 +255,7 @@ N/A - Initial release
 
 ## Version History
 
-- **[2.0.0-alpha.0]** - 2026-05-03 - Template catalog, composition, auth profiles, and GitHub Models AI template generation
+- **[2.0.0]** - 2026-05-03 - Template catalog, composition, auth profiles, and GitHub Models AI template generation
 - **[1.1.0]** - 2026-03-09 - Conditional estimation, multi-story learning, strict/lenient validation modes
 - **[0.0.1]** - 2024-12-29 - Initial release
 
@@ -274,7 +274,7 @@ See [Contributing.md](Contributing.md) for information on how to contribute to t
 
 ---
 
-[Unreleased]: https://github.com/Simao-Pereira-Gomes/atomize/compare/v2.0.0-alpha.0...HEAD
-[2.0.0-alpha.0]: https://github.com/Simao-Pereira-Gomes/atomize/compare/v1.1.0...v2.0.0-alpha.0
+[Unreleased]: https://github.com/Simao-Pereira-Gomes/atomize/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/Simao-Pereira-Gomes/atomize/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/Simao-Pereira-Gomes/atomize/compare/v0.0.1...v1.1.0
 [0.0.1]: https://github.com/Simao-Pereira-Gomes/atomize/releases/tag/v0.0.1

--- a/Contributing.md
+++ b/Contributing.md
@@ -63,7 +63,7 @@ Template should validate successfully
 **Environment**
 - OS: macOS 14.0
 - Node: v20.10.0
-- Atomize: v2.0.0-alpha.0
+- Atomize: v2.0.0
 - Platform: Azure DevOps
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@
 [![Node Version](https://img.shields.io/node/v/@sppg2001/atomize)](https://nodejs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue.svg)](https://www.typescriptlang.org/)
 
-> **Pre-release:** This is 2.0.0-alpha.0 — give it a try! If you hit a blocker, you can fall back to the latest stable release with `npm install -g @sppg2001/atomize`.
-> Feedback and bug reports welcome via [GitHub Issues](https://github.com/Simao-Pereira-Gomes/atomize/issues).
-
 **Break down stories, build up velocity.**
 
 Atomize is a CLI tool that automatically generates granular tasks from user stories using YAML templates. Streamline your agile workflow with preset templates, story learning, and smart estimation distribution.
@@ -36,13 +33,13 @@ Atomize is a CLI tool that automatically generates granular tasks from user stor
 ### Global Installation (Recommended)
 
 ```bash
-npm install -g @sppg2001/atomize@alpha
+npm install -g @sppg2001/atomize
 ```
 
 ### Using npx (No Installation)
 
 ```bash
-npx @sppg2001/atomize@alpha --help
+npx @sppg2001/atomize --help
 ```
 
 ### Local Development

--- a/docs/Cli-Reference.md
+++ b/docs/Cli-Reference.md
@@ -1,6 +1,6 @@
 # Atomize CLI Reference
 
-Complete command-line interface documentation for Atomize v2.0.0-alpha.0.
+Complete command-line interface documentation for Atomize v2.0.0.
 
 ## Table of Contents
 
@@ -30,9 +30,6 @@ Complete command-line interface documentation for Atomize v2.0.0-alpha.0.
 ```bash
 # Global installation (recommended)
 npm install -g @sppg2001/atomize
-
-# Install the alpha
-npm install -g @sppg2001/atomize@alpha
 
 # Verify installation
 atomize --version
@@ -875,7 +872,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Atomize
-        run: npm install -g @sppg2001/atomize@alpha
+        run: npm install -g @sppg2001/atomize
 
       - name: Save connection profile
         run: |

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -52,7 +52,7 @@ User Story (8 points)
 ### Install Globally
 
 ```bash
-npm install -g @sppg2001/atomize@alpha
+npm install -g @sppg2001/atomize
 ```
 
 ### Verify Installation
@@ -65,7 +65,7 @@ atomize --help
 ### Alternative: Use without Installing
 
 ```bash
-npx @sppg2001/atomize@alpha generate template:backend-api
+npx @sppg2001/atomize generate template:backend-api
 ```
 
 ---
@@ -436,7 +436,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Atomize
-        run: npm install -g @sppg2001/atomize@alpha
+        run: npm install -g @sppg2001/atomize
 
       - name: Validate Templates
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sppg2001/atomize",
-	"version": "2.0.0-alpha.0",
+	"version": "2.0.0",
 	"description": "Automatically generate tasks from user stories with smart templates",
 	"type": "module",
 	"main": "./dist/cli/index.js",
@@ -10,7 +10,7 @@
 	},
 	"publishConfig": {
 		"access": "public",
-		"tag": "alpha"
+		"tag": "latest"
 	},
 	"files": [
 		"dist",

--- a/src/services/template/template-catalog.ts
+++ b/src/services/template/template-catalog.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { copyFile, mkdir, readdir, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { logger } from "@config/logger";
 import {
   MixinTemplateSchema,
@@ -320,7 +321,7 @@ export class TemplateCatalog {
   }
 
   private findPackageRoot(): string {
-    let currentDir = __dirname;
+    let currentDir = dirname(fileURLToPath(import.meta.url));
 
     while (currentDir !== dirname(currentDir)) {
       const pkgPath = resolve(currentDir, "package.json");


### PR DESCRIPTION
This pull request promotes Atomize from pre-release (`2.0.0-alpha.0`) to its first stable release (`2.0.0`). It updates all references to the version throughout the documentation and configuration files, and changes the npm publishing tag from `alpha` to `latest`. This means users will now get the stable release by default when installing with npm, and all documentation reflects the stable release status.

**Version and Release Updates**
* Updated the version in `package.json` and all documentation from `2.0.0-alpha.0` to `2.0.0`, marking the first stable release.

**Documentation and Installation Instructions**
* Updated all installation instructions in the documentation to use the stable release (removed `@alpha` from all `npm install` and `npx` commands). 
* Removed the pre-release notice from the `README.md`.

**Changelog and Version History**
* Updated the changelog to reflect the stable release, including link references and version history entries. 