### PR TITLE
Enhance task creation and JSON streaming in generation pipeline

### DIFF
--- a/docs/adr/0028-generate-json-stream-protocol.md
+++ b/docs/adr/0028-generate-json-stream-protocol.md
@@ -1,0 +1,30 @@
+# Generate JSON stream protocol
+
+The VS Code Generate panel shows no progress during live task creation — the webview stays frozen on a spinner until the CLI exits and emits its final JSON blob. To show live counters (stories completed, tasks created), the CLI gains a `--json-stream` flag that emits NDJSON to stdout during execution.
+
+## Decision
+
+`atomize gen --json-stream` writes one JSON line per event to stdout as execution proceeds, then writes the final `AtomizationReport` as the last line. Every line uses a typed envelope:
+
+```
+{ "event": "progress", "data": <ProgressEvent> }
+{ "event": "report",   "data": <AtomizationReport> }
+```
+
+The existing `--json` flag is unchanged — it continues to emit a single JSON blob on exit. `--json` covers dry-run calls from the extension; `--json-stream` covers live-execution calls.
+
+Progress events emitted are `story_start`, `story_complete`, `story_error`, and `task_created`. Per-task events require an `onTaskCreated?: (task: WorkItem) => void` callback added to `createTasksBulk` on the `GenerationPlatform` interface, threaded through `TaskMaterializer` → `StoryProcessor` → `StoryBatchProcessor` → `Atomizer`.
+
+The VS Code extension's `GeneratePanel` reads the stream line-by-line, sends `panel.webview.postMessage` on each progress line to update counter text nodes in place, and only replaces the full panel HTML on the final `report` line. The running-phase HTML is rendered once with counter elements that have known IDs; the postMessage handler patches only those nodes.
+
+## Why not stderr for progress
+
+Stderr is already treated as an error signal by the extension's `spawnJson` error path. Mixing progress events into stderr would require the extension to distinguish error output from progress output on the same channel. Stdout is cleaner: one channel, one framing convention.
+
+## Why typed envelope over shape discrimination
+
+`AtomizationReport` has no `type` field today, so checking `"type" in line` would work now. But the envelope makes the contract explicit and immune to future schema additions to either type. Any consumer checks `line.event` first; the payload shape follows from that.
+
+## Why dry run is excluded
+
+The dry-run latency is dominated by a single `queryWorkItems` call — there is no per-story write loop to observe. A loading spinner is sufficient. Keeping dry run on `--json` avoids changing a stable, tested code path.

--- a/packages/cli/src/cli/commands/generate-application.ts
+++ b/packages/cli/src/cli/commands/generate-application.ts
@@ -30,6 +30,7 @@ export interface GenerateCommandOptions {
   limit?: string;
   story?: string[];
   profile?: string;
+  jsonStream?: boolean;
 }
 
 export interface GenerateConcurrencySettings {
@@ -93,6 +94,7 @@ export interface GenerateCommandApplicationDeps {
       forceNormalize: boolean;
       isTTYSession: boolean;
       profileLabel?: string;
+      jsonStream?: boolean;
     },
     output: OutputSink,
   ): Promise<AtomizationReport>;
@@ -200,6 +202,7 @@ export async function runGenerateCommandApplication(input: {
       forceNormalize,
       isTTYSession,
       profileLabel: options.profile,
+      jsonStream: options.jsonStream,
     },
     output,
   );

--- a/packages/cli/src/cli/commands/generate.command.ts
+++ b/packages/cli/src/cli/commands/generate.command.ts
@@ -65,6 +65,22 @@ export function buildJsonOutput(report: AtomizationReport): { stdout: string; ex
   };
 }
 
+/** @internal Exported for testing */
+export function buildJsonStreamReportLine(report: AtomizationReport): { line: string; exitCode: number } {
+  return {
+    line: JSON.stringify({ event: "report", data: report }),
+    exitCode: report.storiesFailed > 0 ? ExitCode.Failure : ExitCode.Success,
+  };
+}
+
+/** @internal Exported for testing */
+export function getJsonStreamConflictError(options: { json: boolean; jsonStream: boolean }): string | undefined {
+  if (options.json && options.jsonStream) {
+    return "--json-stream and --json are mutually exclusive.";
+  }
+  return undefined;
+}
+
 /**
  * Returns a print function that writes to stdout only when quiet mode is off.
  * @internal Exported for testing
@@ -557,16 +573,25 @@ export function makeGenerateCommand(makeOutput: OutputSinkFactory, prompts: Prom
   )
   .option("--profile <name>", "Named connection profile to use (uses default if omitted)")
   .option("--json", "Emit AtomizationReport as JSON to stdout; implies dry-run and --quiet", false)
+  .option("--json-stream", "Emit NDJSON progress events then final report to stdout; implies --quiet", false)
   .action(async (templateArg: string | undefined, options) => {
       try {
       const isJson = options.json === true;
+      const isJsonStream = options.jsonStream === true;
       const isTTYSession = isInteractiveTerminal();
-      const isQuiet = isJson || options.quiet === true;
+      const isQuiet = isJson || isJsonStream || options.quiet === true;
       const outputPolicy = resolveGenerateOutputPolicy({
         quiet: isQuiet,
         verbose: options.verbose === true,
       });
       const output = makeOutput({ quiet: isQuiet, verbose: options.verbose === true });
+
+      const conflictError = getJsonStreamConflictError({ json: isJson, jsonStream: isJsonStream });
+      if (conflictError) {
+        output.cancel(conflictError);
+        throw new ExitError(ExitCode.Failure);
+      }
+
         if (options.profile) {
         const { getProfile } = await import("@config/connections.config");
         const profile = await getProfile(options.profile);
@@ -593,9 +618,15 @@ export function makeGenerateCommand(makeOutput: OutputSinkFactory, prompts: Prom
         return code;
       };
 
+      const jsonStreamPrintReport = (report: AtomizationReport): number => {
+        const { line, exitCode: code } = buildJsonStreamReportLine(report);
+        process.stdout.write(line + "\n");
+        return code;
+      };
+
       const exitCode = await runGenerateCommandApplication({
         templateArg,
-        options: { ...options, execute: options.execute },
+        options: { ...options, execute: options.execute, jsonStream: isJsonStream },
         config,
         prompts,
         isTTYSession,
@@ -612,13 +643,13 @@ export function makeGenerateCommand(makeOutput: OutputSinkFactory, prompts: Prom
           renderFilterCriteria,
           confirmLiveExecution,
           runWorkflow: runGenerateWorkflow,
-          printReport: isJson ? jsonPrintReport : printReport,
+          printReport: isJson ? jsonPrintReport : isJsonStream ? jsonStreamPrintReport : printReport,
         },
       });
       process.exit(exitCode);
     } catch (error) {
       if (!(error instanceof ExitError)) {
-        if (options.json === true) {
+        if (options.json === true || options.jsonStream === true) {
           if (error instanceof Error) {
             process.stderr.write(`${sanitizeTty(error.message)}\n`);
           }

--- a/packages/cli/src/cli/commands/generate.command.ts
+++ b/packages/cli/src/cli/commands/generate.command.ts
@@ -620,7 +620,7 @@ export function makeGenerateCommand(makeOutput: OutputSinkFactory, prompts: Prom
 
       const jsonStreamPrintReport = (report: AtomizationReport): number => {
         const { line, exitCode: code } = buildJsonStreamReportLine(report);
-        process.stdout.write(line + "\n");
+        process.stdout.write(`${line}\n`);
         return code;
       };
 

--- a/packages/cli/src/cli/orchestrator/atomize-orchestrator.ts
+++ b/packages/cli/src/cli/orchestrator/atomize-orchestrator.ts
@@ -26,9 +26,23 @@ export interface AtomizeOptions {
   dependencyConcurrency: number;
   forceNormalize: boolean;
   isTTYSession: boolean;
+  jsonStream?: boolean;
 }
 
 const noopSpinner: SpinnerHandle = { message: () => {}, stop: () => {}, fail: () => {} };
+
+/** @internal Exported for testing */
+export function createJsonStreamProgressHandler(
+  write: (line: string) => void,
+): (event: ProgressEvent) => void {
+  return (event) => {
+    match(event.type)
+      .with("story_start", "story_complete", "story_error", "task_created", () => {
+        write(JSON.stringify({ event: "progress", data: event }));
+      })
+      .otherwise(() => {});
+  };
+}
 
 /** @internal Exported for testing */
 export function createProgressHandler(
@@ -128,10 +142,22 @@ export async function runAtomization(
   const generationRun = new GenerationRun(platform);
   const storyProgressRef: { current: ProgressHandle | undefined } = { current: undefined };
 
-  const querySpinner = opts.isTTYSession
+  const querySpinner = (!opts.jsonStream && opts.isTTYSession)
     ? output.startSpinner("Querying work items...")
     : noopSpinner;
-  if (!opts.isTTYSession) output.print("Querying work items...");
+  if (!opts.jsonStream && !opts.isTTYSession) output.print("Querying work items...");
+
+  const onProgress = opts.jsonStream
+    ? createJsonStreamProgressHandler((line) => process.stdout.write(line + "\n"))
+    : createProgressHandler(
+        opts.isTTYSession,
+        querySpinner,
+        storyProgressRef,
+        output.print,
+        log.success,
+        log.error,
+        (total) => progress({ max: total, style: "block" }),
+      );
 
   const report = await generationRun.execute(template, {
     dryRun: opts.dryRun,
@@ -141,18 +167,10 @@ export async function runAtomization(
     storyConcurrency: opts.storyConcurrency,
     dependencyConcurrency: opts.dependencyConcurrency,
     forceNormalize: opts.forceNormalize,
-    onProgress: createProgressHandler(
-      opts.isTTYSession,
-      querySpinner,
-      storyProgressRef,
-      output.print,
-      log.success,
-      log.error,
-      (total) => progress({ max: total, style: "block" }),
-    ),
+    onProgress,
   });
 
-  if (report.storiesProcessed > 0) {
+  if (!opts.jsonStream && report.storiesProcessed > 0) {
     if (opts.isTTYSession && storyProgressRef.current) {
       storyProgressRef.current.stop("Processing complete");
     } else {

--- a/packages/cli/src/cli/orchestrator/atomize-orchestrator.ts
+++ b/packages/cli/src/cli/orchestrator/atomize-orchestrator.ts
@@ -148,7 +148,7 @@ export async function runAtomization(
   if (!opts.jsonStream && !opts.isTTYSession) output.print("Querying work items...");
 
   const onProgress = opts.jsonStream
-    ? createJsonStreamProgressHandler((line) => process.stdout.write(line + "\n"))
+    ? createJsonStreamProgressHandler((line) => process.stdout.write(`${line}\n`))
     : createProgressHandler(
         opts.isTTYSession,
         querySpinner,

--- a/packages/cli/src/cli/orchestrator/generate-workflow.ts
+++ b/packages/cli/src/cli/orchestrator/generate-workflow.ts
@@ -19,6 +19,7 @@ export interface GenerateWorkflowOptions {
   forceNormalize: boolean;
   isTTYSession: boolean;
   profileLabel?: string;
+  jsonStream?: boolean;
 }
 
 export async function runGenerateWorkflow(
@@ -44,5 +45,6 @@ export async function runGenerateWorkflow(
     dependencyConcurrency: options.dependencyConcurrency,
     forceNormalize: options.forceNormalize,
     isTTYSession: options.isTTYSession,
+    jsonStream: options.jsonStream,
   }, output);
 }

--- a/packages/cli/src/core/atomizer.ts
+++ b/packages/cli/src/core/atomizer.ts
@@ -44,6 +44,8 @@ export interface ProgressEvent {
   dependenciesCreated?: number;
   /** Error message if type is story_error */
   error?: string;
+  /** The task that was just created (type: task_created) */
+  task?: WorkItem;
 }
 
 /**

--- a/packages/cli/src/core/story-batch-processor.ts
+++ b/packages/cli/src/core/story-batch-processor.ts
@@ -54,13 +54,17 @@ export class StoryBatchProcessor {
 
         emitStoryStart(onProgress, storyIndex, input.stories.length, story);
 
+        const onTaskCreated = onProgress
+          ? (task: WorkItem) => onProgress({ type: "task_created", task, story, storyIndex, totalStories: input.stories.length })
+          : undefined;
+
         try {
           const result = await input.storyProcessor.process(
             story,
             input.orderedTasks,
             input.template,
             input.connectUserEmail,
-            input.options,
+            { ...input.options, onTaskCreated },
             input.warnings,
           );
           results[storyIndex] = result;

--- a/packages/cli/src/core/story-processor.ts
+++ b/packages/cli/src/core/story-processor.ts
@@ -30,7 +30,9 @@ export class StoryProcessor {
     orderedTasks: TemplateTaskDefinition[],
     template: TaskTemplate,
     connectUserEmail: string,
-    options: Pick<AtomizationOptions, "dryRun" | "forceNormalize" | "dependencyConcurrency">,
+    options: Pick<AtomizationOptions, "dryRun" | "forceNormalize" | "dependencyConcurrency"> & {
+      onTaskCreated?: (task: WorkItem) => void;
+    },
     warnings: string[],
   ): Promise<StoryAtomizationResult> {
     logger.info(`Processing: ${story.id} - ${story.title}`);
@@ -80,7 +82,7 @@ export class StoryProcessor {
         story.id,
         calculatedTasks,
         orderedTasks,
-        { dependencyConcurrency: options.dependencyConcurrency },
+        { dependencyConcurrency: options.dependencyConcurrency, onTaskCreated: options.onTaskCreated },
       );
       logger.info(`Created ${tasksCreated.length} tasks`);
     }

--- a/packages/cli/src/core/task-materializer.ts
+++ b/packages/cli/src/core/task-materializer.ts
@@ -7,6 +7,7 @@ import type { CalculatedTask } from "./estimation-calculator";
 
 export interface TaskMaterializationOptions {
   dependencyConcurrency?: number;
+  onTaskCreated?: (task: WorkItem) => void;
 }
 
 /**
@@ -69,7 +70,7 @@ export class TaskMaterializer {
     templateTasks: TemplateTaskDefinition[],
     options: TaskMaterializationOptions = {},
   ): Promise<WorkItem[]> {
-    const createdTasks = await this.platform.createTasksBulk(parentId, calculatedTasks);
+    const createdTasks = await this.platform.createTasksBulk(parentId, calculatedTasks, options.onTaskCreated);
     const dependencyLinks = planDependencyLinks(calculatedTasks, createdTasks, templateTasks);
     await this.createDependencyLinks(dependencyLinks, options.dependencyConcurrency ?? 5);
     return createdTasks;

--- a/packages/cli/src/platforms/adapters/azure-devops/azure-devops.adapter.ts
+++ b/packages/cli/src/platforms/adapters/azure-devops/azure-devops.adapter.ts
@@ -235,6 +235,7 @@ export class AzureDevOpsAdapter implements IPlatformAdapter {
   async createTasksBulk(
     parentId: string,
     tasks: TaskDefinition[],
+    onTaskCreated?: (task: WorkItem) => void,
   ): Promise<WorkItem[]> {
     this.ensureAuthenticated();
 
@@ -253,6 +254,7 @@ export class AzureDevOpsAdapter implements IPlatformAdapter {
         try {
           const created = await this.createTask(parentId, task);
           results[taskIndex] = created;
+          onTaskCreated?.(created);
           return created;
         } catch (error) {
           logger.error(`AzureDevOps: Failed to create task: ${task.title}`, {

--- a/packages/cli/src/platforms/adapters/mock/mock.adapter.ts
+++ b/packages/cli/src/platforms/adapters/mock/mock.adapter.ts
@@ -207,6 +207,7 @@ export class MockPlatformAdapter implements IPlatformAdapter {
   async createTasksBulk(
     parentId: string,
     tasks: TaskDefinition[],
+    onTaskCreated?: (task: WorkItem) => void,
     concurrency = 5
   ): Promise<WorkItem[]> {
     this.ensureAuthenticated();
@@ -225,6 +226,7 @@ export class MockPlatformAdapter implements IPlatformAdapter {
         try {
           const created = await this.createTask(parentId, task);
           results[taskIndex] = created;
+          onTaskCreated?.(created);
           return created;
         } catch (error) {
           logger.error(`MockPlatform: Failed to create task: ${task.title}`, {

--- a/packages/cli/src/platforms/interfaces/platform-capabilities.ts
+++ b/packages/cli/src/platforms/interfaces/platform-capabilities.ts
@@ -26,7 +26,11 @@ export interface StoryLearningPlatform
     ChildTaskReader {}
 
 export interface TaskWriter {
-  createTasksBulk(parentId: string, tasks: TaskDefinition[]): Promise<WorkItem[]>;
+  createTasksBulk(
+    parentId: string,
+    tasks: TaskDefinition[],
+    onTaskCreated?: (task: WorkItem) => void,
+  ): Promise<WorkItem[]>;
 }
 
 export interface DependencyLinker {

--- a/packages/cli/src/templates/custom-field-verifier.ts
+++ b/packages/cli/src/templates/custom-field-verifier.ts
@@ -1,8 +1,8 @@
 import type { ADoFieldSchema } from "@platforms/interfaces/field-schema.interface";
 import { extractCustomFieldRefs } from "@/core/condition-evaluator.js";
 import type { TaskTemplate } from "./schema";
-import { FixableWarningCode } from "./validator";
 import type { ValidationError, ValidationWarning } from "./validator";
+import { FixableWarningCode } from "./validator";
 
 export interface CustomFieldVerificationSummary {
   count: number;

--- a/packages/cli/tests/unit/atomizer.test.ts
+++ b/packages/cli/tests/unit/atomizer.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { inspect } from "node:util";
 import { Atomizer } from "@core/atomizer";
 import { MockPlatformAdapter } from "@platforms/adapters/mock/mock.adapter";
+import type { WorkItem } from "@platforms/interfaces/work-item.interface";
 import type { TaskTemplate } from "@templates/schema";
 import { expectToReject } from "../utils/matchers";
 
@@ -196,6 +197,24 @@ describe("Atomizer", () => {
       };
 
       await expectToReject(atomizer.atomize(invalidTemplate), "Invalid filter");
+    });
+
+    test("onProgress fires task_created once per created task", async () => {
+      await platform.authenticate();
+
+      const createdTasks: WorkItem[] = [];
+      const report = await atomizer.atomize(basicTemplate, {
+        dryRun: false,
+        onProgress: (event) => {
+          if (event.type === "task_created" && event.task) {
+            createdTasks.push(event.task);
+          }
+        },
+      });
+
+      // basicTemplate matches 3 stories × 3 tasks = 9 tasks total
+      expect(createdTasks).toHaveLength(report.tasksCreated);
+      expect(createdTasks.length).toBeGreaterThan(0);
     });
 
     describe("storyIds option", () => {

--- a/packages/cli/tests/unit/generate-command.test.ts
+++ b/packages/cli/tests/unit/generate-command.test.ts
@@ -6,6 +6,8 @@ import type { AtomizationReport } from "@core/atomizer";
 import { writeReportFile } from "@core/report-formatter";
 import {
   buildJsonOutput,
+  buildJsonStreamReportLine,
+  getJsonStreamConflictError,
   getNonInteractiveLiveExecutionError,
   parseConcurrency,
   printReport,
@@ -435,5 +437,43 @@ describe("buildJsonOutput", () => {
 
   test("returns exit code 1 when stories failed", () => {
     expect(buildJsonOutput(makeReport({ storiesFailed: 2 })).exitCode).toBe(ExitCode.Failure);
+  });
+});
+
+describe("buildJsonStreamReportLine", () => {
+  test("wraps the report in a report envelope", () => {
+    const report = makeReport();
+    const { line } = buildJsonStreamReportLine(report);
+    const parsed = JSON.parse(line);
+    expect(parsed.event).toBe("report");
+    expect(parsed.data).toEqual(report);
+  });
+
+  test("returns exit code 0 when no stories failed", () => {
+    expect(buildJsonStreamReportLine(makeReport({ storiesFailed: 0 })).exitCode).toBe(ExitCode.Success);
+  });
+
+  test("returns exit code 1 when stories failed", () => {
+    expect(buildJsonStreamReportLine(makeReport({ storiesFailed: 2 })).exitCode).toBe(ExitCode.Failure);
+  });
+});
+
+describe("getJsonStreamConflictError", () => {
+  test("returns undefined when neither flag is set", () => {
+    expect(getJsonStreamConflictError({ json: false, jsonStream: false })).toBeUndefined();
+  });
+
+  test("returns undefined when only --json is set", () => {
+    expect(getJsonStreamConflictError({ json: true, jsonStream: false })).toBeUndefined();
+  });
+
+  test("returns undefined when only --json-stream is set", () => {
+    expect(getJsonStreamConflictError({ json: false, jsonStream: true })).toBeUndefined();
+  });
+
+  test("returns an error message when both flags are set", () => {
+    const error = getJsonStreamConflictError({ json: true, jsonStream: true });
+    expect(error).toContain("--json-stream");
+    expect(error).toContain("--json");
   });
 });

--- a/packages/cli/tests/unit/json-stream-handler.test.ts
+++ b/packages/cli/tests/unit/json-stream-handler.test.ts
@@ -8,7 +8,9 @@ function makeStory(id: string, title = `Story ${id}`): WorkItem {
 
 function parseFirst(lines: string[]): unknown {
   expect(lines).toHaveLength(1);
-  return JSON.parse(lines[0]!);
+  const [line] = lines;
+  if (line === undefined) throw new Error("Expected one JSON stream line.");
+  return JSON.parse(line);
 }
 
 describe("createJsonStreamProgressHandler — progress events", () => {

--- a/packages/cli/tests/unit/json-stream-handler.test.ts
+++ b/packages/cli/tests/unit/json-stream-handler.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { createJsonStreamProgressHandler } from "@/cli/orchestrator/atomize-orchestrator";
+import type { WorkItem } from "@/platforms/interfaces/work-item.interface";
+
+function makeStory(id: string, title = `Story ${id}`): WorkItem {
+  return { id, title } as WorkItem;
+}
+
+function parseFirst(lines: string[]): unknown {
+  expect(lines).toHaveLength(1);
+  return JSON.parse(lines[0]!);
+}
+
+describe("createJsonStreamProgressHandler — progress events", () => {
+  test("story_start emits a progress envelope", () => {
+    const lines: string[] = [];
+    const handler = createJsonStreamProgressHandler((line) => lines.push(line));
+
+    handler({ type: "story_start", storyIndex: 0, totalStories: 3, story: makeStory("US-1") });
+
+    const parsed = parseFirst(lines) as { event: string; data: { type: string; story: { id: string } } };
+    expect(parsed.event).toBe("progress");
+    expect(parsed.data.type).toBe("story_start");
+    expect(parsed.data.story.id).toBe("US-1");
+  });
+
+  test("story_complete emits a progress envelope", () => {
+    const lines: string[] = [];
+    const handler = createJsonStreamProgressHandler((line) => lines.push(line));
+
+    handler({ type: "story_complete", completedStories: 1, totalStories: 2, story: makeStory("US-2", "Done") });
+
+    const parsed = parseFirst(lines) as { event: string; data: { type: string; completedStories: number } };
+    expect(parsed.event).toBe("progress");
+    expect(parsed.data.type).toBe("story_complete");
+    expect(parsed.data.completedStories).toBe(1);
+  });
+
+  test("story_error emits a progress envelope", () => {
+    const lines: string[] = [];
+    const handler = createJsonStreamProgressHandler((line) => lines.push(line));
+
+    handler({ type: "story_error", completedStories: 1, totalStories: 2, story: makeStory("US-3"), error: "connection timeout" });
+
+    const parsed = parseFirst(lines) as { event: string; data: { type: string; error: string } };
+    expect(parsed.event).toBe("progress");
+    expect(parsed.data.type).toBe("story_error");
+    expect(parsed.data.error).toBe("connection timeout");
+  });
+
+  test("task_created emits a progress envelope", () => {
+    const lines: string[] = [];
+    const handler = createJsonStreamProgressHandler((line) => lines.push(line));
+
+    handler({ type: "task_created", tasksCreated: 3, completedStories: 0, totalStories: 1 });
+
+    const parsed = parseFirst(lines) as { event: string; data: { type: string; tasksCreated: number } };
+    expect(parsed.event).toBe("progress");
+    expect(parsed.data.type).toBe("task_created");
+    expect(parsed.data.tasksCreated).toBe(3);
+  });
+});
+
+describe("createJsonStreamProgressHandler — suppressed events", () => {
+  test.each([
+    "query_start",
+    "query_complete",
+    "dependency_created",
+    "complete",
+  ] as const)("%s produces no output", (eventType) => {
+    const lines: string[] = [];
+    const handler = createJsonStreamProgressHandler((line) => lines.push(line));
+
+    handler({ type: eventType, totalStories: 2, tasksCreated: 1, dependenciesCreated: 0 });
+
+    expect(lines).toHaveLength(0);
+  });
+
+  test("each emitted line is valid JSON", () => {
+    const lines: string[] = [];
+    const handler = createJsonStreamProgressHandler((line) => lines.push(line));
+
+    handler({ type: "story_start", storyIndex: 0, totalStories: 1, story: makeStory("US-1") });
+    handler({ type: "story_complete", completedStories: 1, totalStories: 1, story: makeStory("US-1") });
+
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  });
+});

--- a/packages/vscode-extension/src/__tests__/cli-provider.test.ts
+++ b/packages/vscode-extension/src/__tests__/cli-provider.test.ts
@@ -208,15 +208,15 @@ describe('buildGenDryRunJsonArgs', () => {
 });
 
 describe('buildGenExecuteJsonArgs', () => {
-	it('builds gen --json --execute --auto-approve arguments', () => {
+	it('builds gen --json-stream --execute --auto-approve arguments', () => {
 		expect(buildGenExecuteJsonArgs('/templates/auth.atomize.yaml', 'work-ado', false)).toEqual([
-			'gen', '/templates/auth.atomize.yaml', '--profile', 'work-ado', '--json', '--execute', '--auto-approve',
+			'gen', '/templates/auth.atomize.yaml', '--profile', 'work-ado', '--json-stream', '--execute', '--auto-approve',
 		]);
 	});
 
 	it('appends --continue-on-error when continueOnError is true', () => {
 		expect(buildGenExecuteJsonArgs('/templates/auth.atomize.yaml', 'work-ado', true)).toEqual([
-			'gen', '/templates/auth.atomize.yaml', '--profile', 'work-ado', '--json', '--execute', '--auto-approve', '--continue-on-error',
+			'gen', '/templates/auth.atomize.yaml', '--profile', 'work-ado', '--json-stream', '--execute', '--auto-approve', '--continue-on-error',
 		]);
 	});
 });

--- a/packages/vscode-extension/src/__tests__/generate-html.test.ts
+++ b/packages/vscode-extension/src/__tests__/generate-html.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'bun:test';
+import type { GenerateReport } from '../generate/generate-html.js';
+import { renderGenerateLiveRunning } from '../generate/generate-html.js';
+
+function makeDryReport(overrides?: Partial<GenerateReport>): GenerateReport {
+	return {
+		templateName: 'default',
+		storiesProcessed: 3,
+		storiesSuccess: 3,
+		storiesFailed: 0,
+		tasksCalculated: 6,
+		tasksCreated: 0,
+		tasksSkipped: 0,
+		dryRun: true,
+		results: [],
+		errors: [],
+		warnings: [],
+		executionTime: 500,
+		...overrides,
+	};
+}
+
+describe('renderGenerateLiveRunning', () => {
+	it('contains live-stories and live-tasks counter elements', () => {
+		const html = renderGenerateLiveRunning(makeDryReport(), 'templates/auth.atomize.yaml', 'work-ado');
+		expect(html).toContain('id="live-stories"');
+		expect(html).toContain('id="live-tasks"');
+	});
+
+	it('contains a progress-fill bar element', () => {
+		const html = renderGenerateLiveRunning(makeDryReport(), 'templates/auth.atomize.yaml', 'work-ado');
+		expect(html).toContain('id="progress-fill"');
+	});
+
+	it('contains a liveProgress message handler in the page script', () => {
+		const html = renderGenerateLiveRunning(makeDryReport(), 'templates/auth.atomize.yaml', 'work-ado');
+		expect(html).toContain('liveProgress');
+	});
+});

--- a/packages/vscode-extension/src/__tests__/generate-panel.test.ts
+++ b/packages/vscode-extension/src/__tests__/generate-panel.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test';
+import { parseNdjsonLines } from '../generate/generate-ndjson.js';
+import type { GenerateReport } from '../generate/generate-html.js';
+
+function makeReport(overrides?: Partial<GenerateReport>): GenerateReport {
+	return {
+		templateName: 'default',
+		storiesProcessed: 2,
+		storiesSuccess: 2,
+		storiesFailed: 0,
+		tasksCalculated: 4,
+		tasksCreated: 4,
+		tasksSkipped: 0,
+		dryRun: false,
+		results: [],
+		errors: [],
+		warnings: [],
+		executionTime: 1000,
+		...overrides,
+	};
+}
+
+describe('parseNdjsonLines', () => {
+	it('ignores lines with unrecognised event types', () => {
+		const events: unknown[] = [];
+		const lines = [
+			JSON.stringify({ event: 'start', data: {} }),
+			JSON.stringify({ event: 'unknown', data: { storiesCompleted: 1, totalStories: 1, tasksCreated: 1 } }),
+			JSON.stringify({ event: 'progress', data: { storiesCompleted: 1, totalStories: 1, tasksCreated: 1 } }),
+		];
+		parseNdjsonLines(lines, e => events.push(e));
+		expect(events).toHaveLength(1);
+	});
+
+	it('skips malformed non-JSON lines without throwing', () => {
+		const report = makeReport();
+		const lines = [
+			'not json at all',
+			'{broken',
+			JSON.stringify({ event: 'report', data: report }),
+		];
+		expect(parseNdjsonLines(lines, () => undefined)).toEqual(report);
+	});
+
+	it('returns null when no report event line is present', () => {
+		const lines = [
+			JSON.stringify({ event: 'progress', data: { storiesCompleted: 1, totalStories: 2, tasksCreated: 0 } }),
+		];
+		expect(parseNdjsonLines(lines, () => undefined)).toBeNull();
+	});
+
+	it('returns the GenerateReport from the report event line', () => {
+		const report = makeReport({ tasksCreated: 7 });
+		const lines = [
+			JSON.stringify({ event: 'progress', data: { storiesCompleted: 1, totalStories: 2, tasksCreated: 3 } }),
+			JSON.stringify({ event: 'report', data: report }),
+		];
+		const result = parseNdjsonLines(lines, () => undefined);
+		expect(result).toEqual(report);
+	});
+
+	it('calls onProgress for each progress event line', () => {
+		const events: unknown[] = [];
+		const lines = [
+			JSON.stringify({ event: 'progress', data: { storiesCompleted: 1, totalStories: 3, tasksCreated: 2 } }),
+			JSON.stringify({ event: 'progress', data: { storiesCompleted: 2, totalStories: 3, tasksCreated: 5 } }),
+		];
+		parseNdjsonLines(lines, e => events.push(e));
+		expect(events).toEqual([
+			{ storiesCompleted: 1, totalStories: 3, tasksCreated: 2 },
+			{ storiesCompleted: 2, totalStories: 3, tasksCreated: 5 },
+		]);
+	});
+});

--- a/packages/vscode-extension/src/__tests__/generate-panel.test.ts
+++ b/packages/vscode-extension/src/__tests__/generate-panel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
-import { parseNdjsonLines } from '../generate/generate-ndjson.js';
 import type { GenerateReport } from '../generate/generate-html.js';
+import { parseNdjsonLines } from '../generate/generate-ndjson.js';
 
 function makeReport(overrides?: Partial<GenerateReport>): GenerateReport {
 	return {

--- a/packages/vscode-extension/src/catalog/show-resolved-template-command.ts
+++ b/packages/vscode-extension/src/catalog/show-resolved-template-command.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import * as vscode from 'vscode';
-import { isAtomizeDocument } from '../authoring/language-detection.js';
 import { resolveCommandDocument } from '../authoring/command-document-resolution.js';
+import { isAtomizeDocument } from '../authoring/language-detection.js';
 import { buildResolveArgs, probeCli } from '../cli/cli-provider.js';
 import { extendedEnv } from '../cli/env-utils.js';
 import { getConfiguredCliPath } from '../config/atomize-configuration.js';

--- a/packages/vscode-extension/src/cli/cli-provider.ts
+++ b/packages/vscode-extension/src/cli/cli-provider.ts
@@ -123,7 +123,7 @@ export function buildGenDryRunJsonArgs(filePath: string, profile: string): strin
 }
 
 export function buildGenExecuteJsonArgs(filePath: string, profile: string, continueOnError: boolean): string[] {
-	const args = ['gen', filePath, '--profile', profile, '--json', '--execute', '--auto-approve'];
+	const args = ['gen', filePath, '--profile', profile, '--json-stream', '--execute', '--auto-approve'];
 	if (continueOnError) args.push('--continue-on-error');
 	return args;
 }

--- a/packages/vscode-extension/src/generate/generate-html.ts
+++ b/packages/vscode-extension/src/generate/generate-html.ts
@@ -104,7 +104,9 @@ details:not([open])>summary{border-bottom:none!important;margin-bottom:0!importa
 .split-menu::before{content:'';position:absolute;top:-7px;right:7px;width:0;height:0;border-left:7px solid transparent;border-right:7px solid transparent;border-bottom:7px solid rgba(255,255,255,.12)}
 .split-menu::after{content:'';position:absolute;top:-6px;right:8px;width:0;height:0;border-left:6px solid transparent;border-right:6px solid transparent;border-bottom:6px solid var(--vscode-menu-background,#252526)}
 .menu-row{display:flex;align-items:flex-start;gap:8px;cursor:pointer;padding:6px 12px;margin:0;width:100%;box-sizing:border-box;transition:background .08s}
-.menu-row:hover{background:rgba(255,255,255,.07)}`;
+.menu-row:hover{background:rgba(255,255,255,.07)}
+.progress-track{height:3px;background:rgba(255,255,255,.09);border-radius:2px;overflow:hidden;flex:1}
+.progress-fill{height:100%;background:var(--vscode-focusBorder);border-radius:2px;transition:width .45s ease}`;
 
 function panelHeader(
 	mode: 'default' | 'compact',
@@ -451,6 +453,32 @@ ${script}
 
 const SWITCH_MODE_SCRIPT = `function switchMode(m) { vscode.postMessage({ type: 'switchMode', mode: m }); }`;
 
+const LIVE_PROGRESS_SCRIPT = `window.addEventListener('message', function(e) {
+  var msg = e.data;
+  if (!msg || msg.type !== 'liveProgress') return;
+  var storiesEl = document.getElementById('live-stories');
+  var tasksEl   = document.getElementById('live-tasks');
+  var fillEl    = document.getElementById('progress-fill');
+  if (!storiesEl || !tasksEl) return;
+  var total = msg.totalStories;
+  var done  = msg.storiesCompleted;
+  var tasks = msg.tasksCreated;
+  storiesEl.textContent = done + ' / ' + total + ' stories';
+  tasksEl.textContent   = String(tasks);
+  if (fillEl) fillEl.style.width = (total > 0 ? (done / total) * 100 : 0) + '%';
+  [
+    { el: storiesEl, color: 'var(--vscode-descriptionForeground)' },
+    { el: tasksEl,   color: 'var(--vscode-testing-iconPassed)' },
+  ].forEach(function(item) {
+    item.el.style.transition = 'none';
+    item.el.style.color = '#ffffff';
+    requestAnimationFrame(function() {
+      item.el.style.transition = 'color 0.5s ease-out';
+      item.el.style.color = item.color;
+    });
+  });
+});`;
+
 const SPLIT_BUTTON_SCRIPT = `
 ${SWITCH_MODE_SCRIPT}
 function toggleMenu(e) {
@@ -562,14 +590,27 @@ export function renderGenerateLiveRunning(
 	const shortFile = fileName.split(/[/\\]/).pop() ?? fileName;
 	const header = panelHeader('default', false, shortFile, profile, dryReport.templateName);
 	const collapsed = collapsedDryRun(dryReport);
+	const totalStories = dryReport.storiesSuccess;
 	const body = `${header}${collapsed}
 <div style="border-top:1px solid var(--vscode-panel-border,#3d3d3d);margin-bottom:14px"></div>
 <div style="display:flex;align-items:center;gap:10px;padding:8px 0;color:var(--vscode-descriptionForeground)">
   <div class="spinner"></div>
   <span style="font-size:.9em">Creating tasks in <strong style="color:var(--vscode-editor-foreground)">${esc(profile)}</strong>…</span>
 </div>
-<div style="font-size:.8em;color:var(--vscode-descriptionForeground);margin-top:4px;padding-left:24px">Story 1 of ${dryReport.storiesSuccess}</div>`;
-	return page('Atomize: Generate — Creating…', body, '');
+<div style="padding-left:24px;margin-top:4px">
+  <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+    <div class="progress-track" style="flex:1">
+      <div class="progress-fill" id="progress-fill" style="width:0%"></div>
+    </div>
+    <span id="live-stories" style="font-size:.78em;color:var(--vscode-descriptionForeground);flex-shrink:0">0 / ${totalStories} stories</span>
+  </div>
+  <div style="font-size:.78em;color:var(--vscode-descriptionForeground)">
+    <span style="color:var(--vscode-testing-iconPassed)">✓</span>
+    <span id="live-tasks" style="font-weight:600;color:var(--vscode-testing-iconPassed)">0</span>
+    <span> tasks created</span>
+  </div>
+</div>`;
+	return page('Atomize: Generate — Creating…', body, LIVE_PROGRESS_SCRIPT);
 }
 
 export function renderGenerateLiveSuccess(

--- a/packages/vscode-extension/src/generate/generate-ndjson.ts
+++ b/packages/vscode-extension/src/generate/generate-ndjson.ts
@@ -1,0 +1,32 @@
+import type { GenerateReport } from './generate-html.js';
+
+export interface NdjsonProgressData {
+	storiesCompleted: number;
+	totalStories: number;
+	tasksCreated: number;
+}
+
+export function parseNdjsonLines(
+	lines: string[],
+	onProgress: (data: NdjsonProgressData) => void,
+): GenerateReport | null {
+	let report: GenerateReport | null = null;
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(trimmed);
+		} catch {
+			continue;
+		}
+		if (typeof parsed !== 'object' || parsed === null) continue;
+		const obj = parsed as Record<string, unknown>;
+		if (obj['event'] === 'progress' && typeof obj['data'] === 'object' && obj['data'] !== null) {
+			onProgress(obj['data'] as NdjsonProgressData);
+		} else if (obj['event'] === 'report' && typeof obj['data'] === 'object' && obj['data'] !== null) {
+			report = obj['data'] as GenerateReport;
+		}
+	}
+	return report;
+}

--- a/packages/vscode-extension/src/generate/generate-ndjson.ts
+++ b/packages/vscode-extension/src/generate/generate-ndjson.ts
@@ -22,10 +22,10 @@ export function parseNdjsonLines(
 		}
 		if (typeof parsed !== 'object' || parsed === null) continue;
 		const obj = parsed as Record<string, unknown>;
-		if (obj['event'] === 'progress' && typeof obj['data'] === 'object' && obj['data'] !== null) {
-			onProgress(obj['data'] as NdjsonProgressData);
-		} else if (obj['event'] === 'report' && typeof obj['data'] === 'object' && obj['data'] !== null) {
-			report = obj['data'] as GenerateReport;
+		if (obj.event === 'progress' && typeof obj.data === 'object' && obj.data !== null) {
+			onProgress(obj.data as NdjsonProgressData);
+		} else if (obj.event === 'report' && typeof obj.data === 'object' && obj.data !== null) {
+			report = obj.data as GenerateReport;
 		}
 	}
 	return report;

--- a/packages/vscode-extension/src/generate/generate-panel.ts
+++ b/packages/vscode-extension/src/generate/generate-panel.ts
@@ -1,7 +1,9 @@
+import { createInterface } from 'node:readline';
 import { spawn } from 'node:child_process';
 import * as vscode from 'vscode';
 import { buildGenDryRunJsonArgs, buildGenExecuteJsonArgs, CLI_EXIT_CODES } from '../cli/cli-provider.js';
 import { extendedEnv } from '../cli/env-utils.js';
+import { parseNdjsonLines } from './generate-ndjson.js';
 import { getDefaultProfile, getPreviewLayout } from '../config/atomize-configuration.js';
 import { pickProfile } from '../profiles/profile-picker.js';
 import type { GenerateReport } from './generate-html.js';
@@ -41,6 +43,50 @@ function spawnJson(cliPath: string, args: string[]): Promise<SpawnResult> {
 			} catch {
 				resolve({ error: 'cli', stderr: stderr.trim() || 'Failed to parse CLI output' });
 			}
+		});
+		proc.on('error', err => resolve({ error: 'cli', stderr: err.message }));
+	});
+}
+
+type ProgressMessage = { storiesCompleted: number; totalStories: number; tasksCreated: number };
+
+function spawnJsonStream(
+	cliPath: string,
+	args: string[],
+	onProgress: (data: ProgressMessage) => void,
+): Promise<SpawnResult> {
+	return new Promise(resolve => {
+		const proc = spawn(cliPath, args, { shell: false, env: extendedEnv() });
+		const lines: string[] = [];
+		let stderr = '';
+		const rl = createInterface({ input: proc.stdout, crlfDelay: Infinity });
+		rl.on('line', line => {
+			lines.push(line);
+			// Parse incrementally so onProgress fires as lines arrive
+			const trimmed = line.trim();
+			if (!trimmed) return;
+			let parsed: unknown;
+			try { parsed = JSON.parse(trimmed); } catch { return; }
+			if (typeof parsed !== 'object' || parsed === null) return;
+			const obj = parsed as Record<string, unknown>;
+			if (obj['event'] === 'progress' && typeof obj['data'] === 'object' && obj['data'] !== null) {
+				onProgress(obj['data'] as ProgressMessage);
+			}
+		});
+		proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+		proc.on('close', code => {
+			if (code !== 0) {
+				const kind = code === CLI_EXIT_CODES.AuthFailure ? 'auth' as const : 'cli' as const;
+				const cleanStderr = stderr.split('\n').filter(l => !/^\(node:\d+\)/.test(l) && !/^\(Use `node /.test(l)).join('\n').trim();
+				resolve({ error: kind, stderr: cleanStderr.trim() || 'CLI error during task creation.' });
+				return;
+			}
+			const report = parseNdjsonLines(lines, () => undefined);
+			if (!report) {
+				resolve({ error: 'cli', stderr: stderr.trim() || 'No report received from CLI stream.' });
+				return;
+			}
+			resolve({ report });
 		});
 		proc.on('error', err => resolve({ error: 'cli', stderr: err.message }));
 	});
@@ -175,9 +221,17 @@ export class GeneratePanel {
 		this._panel.title = `Atomize: ${fileName} (Generate — Creating…)`;
 		this._panel.webview.html = renderGenerateLiveRunning(dryReport, fileName, this._profile);
 
-		const outcome = await spawnJson(
+		const outcome = await spawnJsonStream(
 			this._cliPath,
 			buildGenExecuteJsonArgs(this._fileUri.fsPath, this._profile, this._continueOnError),
+			data => {
+				this._panel.webview.postMessage({
+					type: 'liveProgress',
+					storiesCompleted: data.storiesCompleted,
+					totalStories: data.totalStories,
+					tasksCreated: data.tasksCreated,
+				});
+			},
 		);
 
 		this._panel.title = `Atomize: ${fileName} (Generate — Done)`;

--- a/packages/vscode-extension/src/generate/generate-panel.ts
+++ b/packages/vscode-extension/src/generate/generate-panel.ts
@@ -1,9 +1,8 @@
-import { createInterface } from 'node:readline';
 import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
 import * as vscode from 'vscode';
 import { buildGenDryRunJsonArgs, buildGenExecuteJsonArgs, CLI_EXIT_CODES } from '../cli/cli-provider.js';
 import { extendedEnv } from '../cli/env-utils.js';
-import { parseNdjsonLines } from './generate-ndjson.js';
 import { getDefaultProfile, getPreviewLayout } from '../config/atomize-configuration.js';
 import { pickProfile } from '../profiles/profile-picker.js';
 import type { GenerateReport } from './generate-html.js';
@@ -16,6 +15,7 @@ import {
 	renderGenerateLiveSuccess,
 	renderGenerateLoading,
 } from './generate-html.js';
+import { parseNdjsonLines } from './generate-ndjson.js';
 
 interface SwitchModeMessage { type: 'switchMode'; mode: 'default' | 'compact'; }
 interface CreateTasksMessage { type: 'createTasks'; continueOnError: boolean; }
@@ -69,8 +69,8 @@ function spawnJsonStream(
 			try { parsed = JSON.parse(trimmed); } catch { return; }
 			if (typeof parsed !== 'object' || parsed === null) return;
 			const obj = parsed as Record<string, unknown>;
-			if (obj['event'] === 'progress' && typeof obj['data'] === 'object' && obj['data'] !== null) {
-				onProgress(obj['data'] as ProgressMessage);
+			if (obj.event === 'progress' && typeof obj.data === 'object' && obj.data !== null) {
+				onProgress(obj.data as ProgressMessage);
 			}
 		});
 		proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });

--- a/packages/vscode-extension/src/validation/validation-html.ts
+++ b/packages/vscode-extension/src/validation/validation-html.ts
@@ -1,5 +1,5 @@
-import type { ValidationResult } from './diagnostics.js';
 import css from '../webview/styles.generated.css';
+import type { ValidationResult } from './diagnostics.js';
 
 const CODE_CLS = 'font-mono text-[0.9em] text-[#e0e0e0] bg-white/[0.09] border border-white/[0.12] rounded-[3px] px-1 mx-[3px]';
 


### PR DESCRIPTION
This pull request introduces a new `--json-stream` flag to the CLI's generate command, enabling real-time NDJSON progress reporting for improved integration with the VS Code extension. It adds a streaming protocol for progress events, updates the relevant interfaces and workflows to support per-task progress callbacks, and ensures mutual exclusivity between `--json` and `--json-stream`. The changes also propagate the new progress event handling through the core orchestration and platform layers.

**Key changes:**

**1. JSON Stream Protocol and CLI Flag Support**
- Added a new `--json-stream` flag to the generate command, emitting NDJSON progress events and a final report to stdout for live updates in clients like the VS Code extension. The flag is mutually exclusive with `--json`. 

**2. Progress Event Handling and Streaming**
- Introduced a typed envelope for progress and report events in the stream, with a new `task_created` event emitted per task. Added `createJsonStreamProgressHandler` to handle streaming output, and updated orchestrator logic to use this handler when `--json-stream` is enabled. 

**3. Per-Task Progress Callback Propagation**
- Extended the `createTasksBulk` method in the `TaskWriter` interface and all platform adapters to accept an optional `onTaskCreated` callback, invoked for each created task. This callback is threaded through `TaskMaterializer`, `StoryProcessor`, and `StoryBatchProcessor`. 
**4. Workflow and Option Plumbing**
- Updated all relevant interfaces (`GenerateCommandOptions`, `AtomizeOptions`, `GenerateWorkflowOptions`) and workflow functions to support the new `jsonStream` option, ensuring the flag is correctly propagated throughout the call stack. 

**5. Testing and Documentation**
- Added unit tests verifying that the `task_created` event fires once per created task, and documented the new protocol and design decisions in an ADR.